### PR TITLE
Adding responsiveness to the buttons in homepage. 

### DIFF
--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -208,15 +208,7 @@ export const Date = styled.img`
    cursor: pointer;
 
 
-   @media only screen and (width: 360px){
-    height: 20px;
-    width: 120px;
-    padding: 15px;
-    margin-right: -10%;
-    padding-bottom:2-8px;
-   }
-
-   @media only screen and (max-width: 768px) {
+   @media only screen and (max-width: 361px){
      display: inline-flex;
      width: 120px;
      padding: 15px;
@@ -224,6 +216,20 @@ export const Date = styled.img`
      margin-right: -1%;
      padding-bottom: 35px;
      font-size: 1.5em;
+     margin-left: -20%;
+   }
+
+   @media only screen and (min-device-width: 375px) 
+                      and (max-device-width: 812px) 
+                      and (-webkit-min-device-pixel-ratio: 3) {
+     display: inline-flex;
+     width: 120px;
+     padding: 15px;
+     height: 30px;
+     margin-right: -1%;
+     padding-bottom: 35px;
+     font-size: 1.5em;
+     margin-left: 20%;
    }
 
  `;
@@ -239,15 +245,17 @@ export const Date = styled.img`
    cursor: pointer;
 
 
-   @media only screen and (min-width: 321px) and (width: 360px){
-    height: 40px;
-    width: 130px;
-    padding: 15px;
-    margin-right: -1%;
-    padding-bottom:28px;
+   @media only screen and (min-width: 321px) and (max-width: 361px){
+     width: 130px;
+     padding: 15px;
+     height: 40px;
+     margin-right: -20%;
+     padding-bottom: 35px;
    }
 
-   @media only screen and (max-width: 768px) {
+   @media only screen and (min-device-width: 375px) 
+                      and (max-device-width: 812px) 
+                      and (-webkit-min-device-pixel-ratio: 3){
      width: 130px;
      padding: 15px;
      height: 40px;

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -321,7 +321,7 @@ export const Date = styled.img`
    }
   `;
 
-  export const Apply = styled.img`
+  export const Register = styled.img`
     height: 80px;
     width: 80px;
     margin-top: -13%;
@@ -351,8 +351,8 @@ function home2() {
         </Content>
         <Date src={require("../assets/images/date.png").default} />
          <Buttons>
-          <Button1 class = "Apply">
-           <Apply src={require("../assets/images/devfolio.png").default} />
+          <Button1>
+           <Register src={require("../assets/images/devfolio.png").default} />
             Apply
           </Button1>
           <Button2>

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -11,6 +11,7 @@ export const Raisebox = styled.div`
   border-radius: 10px;
 
   @media only screen and (max-width: 320px){
+    height: 110vh;
     margin-left: -15%;
   }
   @media only screen and (min-width: 321px) and (max-width: 360px) {
@@ -182,10 +183,14 @@ export const Date = styled.img`
    margin-left: 45%;
    margin-top: -7%;
 
+   @media screen and (max-width: 360px){
+          margin-left: -25%;
+   }
+
    @media screen and (max-width: 960px) {
      width: 450px;
      margin-left: -20%;
-     margin-top: 99%;
+     margin-top: 9%;
    }
  `;
 
@@ -196,33 +201,58 @@ export const Date = styled.img`
    border: none;
    color: white;
    font-size: 2.6em;
-   font-weight: 500;
+   font-weight: 400;
    margin-left: 20px;
    background-color: #0360DE;
    margin-top:-5%;
+   cursor: pointer;
+
+
+   @media only screen and (width: 360px){
+    height: 20px;
+    width: 120px;
+    padding: 15px;
+    margin-right: -10%;
+    padding-bottom:2-8px;
+   }
+
    @media only screen and (max-width: 768px) {
+     display: inline-flex;
      width: 120px;
      padding: 15px;
      height: 30px;
      margin-right: -1%;
-     padding-bottom: 28px;
+     padding-bottom: 35px;
+     font-size: 1.5em;
    }
+
  `;
 
  export const Button2 = styled.button`
-   padding: 15px;
-   width: 220px;
+   padding: 18px;
+   width: 250px;
    border-radius: 10px;
    border: none;
    margin-left: 25px;
    background-color: black;
    margin-top:-5%;
+   cursor: pointer;
+
+
+   @media only screen and (min-width: 321px) and (width: 360px){
+    height: 40px;
+    width: 130px;
+    padding: 15px;
+    margin-right: -1%;
+    padding-bottom:28px;
+   }
+
    @media only screen and (max-width: 768px) {
-     width: 120px;
+     width: 130px;
      padding: 15px;
-     height: 30px;
-     margin-right: -1%;
-     padding-bottom: 28px;
+     height: 40px;
+     margin-right: -15%;
+     padding-bottom: 35px;
    }
  `;
 
@@ -232,14 +262,33 @@ export const Date = styled.img`
    margin-top: -7%;
    margin-bottom: -12%;
    margin-left: -3%;
+
+   @media only screen and (max-width: 768px) {
+     height: 60px;
+     width: 120px;
+     margin-top: -10%;
+     margin-left: -12%;
+     margin-bottom: -1%;
+     padding-bottom: 15px;
+   }
   `;
 
-  export const Register = styled.img`
+  export const Apply = styled.img`
     height: 80px;
     width: 80px;
     margin-top: -13%;
     margin-bottom: -12%;
     margin-left: -10%;
+
+
+   @media only screen and (max-width: 768px) {
+     height: 60px;
+     width: 50px;
+     margin-top: -12%;
+     margin-bottom: -10%;
+     margin-left: -20%;
+     padding-bottom: 18px;
+   }
    `;
 
 function home2() {
@@ -254,7 +303,10 @@ function home2() {
         </Content>
         <Date src={require("../assets/images/date.png").default} />
          <Buttons>
-          <Button1><Register src={require("../assets/images/devfolio.png").default} />Apply</Button1>
+          <Button1 class = "Apply">
+           <Apply src={require("../assets/images/devfolio.png").default} />
+            Apply
+          </Button1>
           <Button2>
             <Discord src={require("../assets/images/discord.png").default} />
           </Button2>

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -23,6 +23,7 @@ export const Raisebox = styled.div`
   }
 
   @media only screen and (min-width: 481px) and (max-width: 768px) {
+    height: 110vh;
     margin-left: -5%;
   }
 `;
@@ -76,9 +77,9 @@ export const Content = styled.h1`
     padding-right:16%;
   }
   @media only screen and (min-width: 769px) and (max-width: 936px) {
-
     padding-left:10%;
-    margin-left:25%;
+    margin-left:20%;
+    margin-top: -27%; 
     padding-right:10%;
     font-size:1.6rem;
   }
@@ -115,14 +116,14 @@ export const Image = styled.img`
 
   @media only screen and (min-width: 481px) and (max-width: 768px) {
     height: 70vh;
-    margin-left: -18%;
-    margin-top: -15%;
+    margin-left: -9%;
+    margin-top: -5%;
 
   }
   @media only screen and (min-width: 769px) and (max-width: 936px) {
     height: 85vh;
-    margin-left:-20%;
-    margin-top:-10%;
+    margin-left:-10%;
+    margin-top:-5%; 
   }
   @media only screen and (min-width: 937px) and (max-width: 1024px) {
     height: 75vh;
@@ -145,13 +146,11 @@ export const Date = styled.img`
     margin-left: 7%;
     margin-bottom:5%;
   }
-
-
+  
   @media only screen and (min-width: 361px) and (max-width: 480px) {
     height: 14vh;
     margin-top: 0;
-    margin-left: 6%;
-
+    margin-left: 3.8%;
   }
   @media only screen and (min-width: 441px) and (max-width: 540px) {
     height:17vh;
@@ -161,16 +160,17 @@ export const Date = styled.img`
   @media only screen and (min-width: 541px) and (max-width: 768px) {
     height:17vh;
     margin:0 auto;
+    margin-left: 45%;
   }
   @media only screen and (min-width: 769px) and (max-width: 936px) {
     height:20vh;
-    margin-left: 25%;
-    margin-top: -25%;
+    margin-left: 45%;
+    margin-top: -5%;
   }
   @media only screen and (min-width: 937px) and (max-width: 1024px) {
-    height:20vh;
-    margin-left: 15%;
-    margin-top: -5%;
+    height:15vh;
+    margin-left: 26%;
+    margin-top: -15%;
   }
   @media only screen and (min-width: 1025px) and (max-width: 1200px) {
     height:25vh;
@@ -206,9 +206,8 @@ export const Date = styled.img`
    background-color: #0360DE;
    margin-top:-5%;
    cursor: pointer;
-
-
-   @media only screen and (max-width: 361px){
+   
+    @media only screen and (max-width: 360px){
      display: inline-flex;
      width: 120px;
      padding: 15px;
@@ -216,12 +215,10 @@ export const Date = styled.img`
      margin-right: -1%;
      padding-bottom: 35px;
      font-size: 1.5em;
-     margin-left: -20%;
+     margin-left: 1%;
    }
-
-   @media only screen and (min-device-width: 375px) 
-                      and (max-device-width: 812px) 
-                      and (-webkit-min-device-pixel-ratio: 3) {
+   
+   @media only screen and (min-width: 361px) and (max-width: 440px) {
      display: inline-flex;
      width: 120px;
      padding: 15px;
@@ -230,6 +227,33 @@ export const Date = styled.img`
      padding-bottom: 35px;
      font-size: 1.5em;
      margin-left: 20%;
+   }
+   
+   @media only screen and (min-width: 441px) and (max-width: 540px) {
+     display: auto;
+   }
+   
+   @media only screen and (min-width: 541px) and (max-width: 768px) {
+     display: inline-flex;
+     width: 120px;
+     padding: 15px;
+     height: 30px;
+     margin-right: -1%;
+     padding-bottom: 35px;
+     font-size: 1.5em;
+     margin-left: 15%;
+     margin-top: -30%;
+   }
+   @media only screen and (min-width: 769px) and (max-width: 936px) {
+     display: auto;
+     margin-right: 9%;
+     margin-bottom: 15%;     
+   }
+   @media only screen and (min-width: 937px) and (max-width: 1024px) {
+     display: auto;
+   }
+   @media only screen and (min-width: 1025px) and (max-width: 1200px) {
+     display: auto;
    }
 
  `;
@@ -243,24 +267,40 @@ export const Date = styled.img`
    background-color: black;
    margin-top:-5%;
    cursor: pointer;
-
-
-   @media only screen and (min-width: 321px) and (max-width: 361px){
+   
+      @media only screen and (max-width: 360px){
      width: 130px;
      padding: 15px;
      height: 40px;
      margin-right: -20%;
      padding-bottom: 35px;
    }
-
-   @media only screen and (min-device-width: 375px) 
-                      and (max-device-width: 812px) 
-                      and (-webkit-min-device-pixel-ratio: 3){
-     width: 130px;
+   @media only screen and (min-width: 361px) and (max-width: 440px) {
+          width: 130px;
      padding: 15px;
      height: 40px;
      margin-right: -15%;
      padding-bottom: 35px;
+   }
+   @media only screen and (min-width: 441px) and (max-width: 540px) {
+     display: auto;
+   }
+   @media only screen and (min-width: 541px) and (max-width: 768px) {
+     width: 130px;
+     padding: 15px;
+     height: 40px;
+     margin-right: -85%;
+     padding-bottom: 35px;
+   }
+   @media only screen and (min-width: 769px) and (max-width: 936px) {
+     display: auto;
+     margin-right: -120%;
+   }
+   @media only screen and (min-width: 937px) and (max-width: 1024px) {
+     display: auto;
+   }
+   @media only screen and (min-width: 1025px) and (max-width: 1200px) {
+     display: auto;
    }
  `;
 


### PR DESCRIPTION
## Description

Please read the [Contribution Guidelines](../CONTRIBUTING.md) before opening a pull request.

### Summary

The Devfolio Apply and Discord buttons have been modified to have both images and the text inside the button. Used media queries to manipulate the format and position of the buttons in accordance with the screen size of an iPhone X show in the posted screenshot. Had a bit of trouble dealing with the apply button as it had both an image and text to combine. 


### Browser checklist

This PR has been tested in the following browsers:

- [x] Chrome
- [ ] Safari
- [ ] Firefox

### Closes issue #32 

![iphone X mobile](https://user-images.githubusercontent.com/79113907/121273132-5d322780-c87c-11eb-8ff5-657bfaed48b1.png)

